### PR TITLE
feat: change header on scroll and center search

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -206,10 +206,12 @@ h6 {
 }
 
 .header .search-container {
-  position: relative;
-  flex: 1;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   max-width: 400px;
-  margin: 0 20px;
+  width: 100%;
 }
 
 .header .search-container input {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -12,15 +12,15 @@
   /**
    * Apply .scrolled class to the body as the page is scrolled down
    */
-  // function toggleScrolled() {
-  //   const selectBody = document.querySelector('body');
-  //   const selectHeader = document.querySelector('#header');
-  //   if (!selectHeader.classList.contains('scroll-up-sticky') && !selectHeader.classList.contains('sticky-top') && !selectHeader.classList.contains('fixed-top')) return;
-  //   window.scrollY > 100 ? selectBody.classList.add('scrolled') : selectBody.classList.remove('scrolled');
-  // }
+  function toggleScrolled() {
+    const selectBody = document.querySelector('body');
+    const selectHeader = document.querySelector('#header');
+    if (!selectHeader.classList.contains('scroll-up-sticky') && !selectHeader.classList.contains('sticky-top') && !selectHeader.classList.contains('fixed-top')) return;
+    window.scrollY > 100 ? selectBody.classList.add('scrolled') : selectBody.classList.remove('scrolled');
+  }
 
-  // document.addEventListener('scroll', toggleScrolled);
-  // window.addEventListener('load', toggleScrolled);
+  document.addEventListener('scroll', toggleScrolled);
+  window.addEventListener('load', toggleScrolled);
 
   /**
    * Mobile nav toggle

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 <body class="index-page">
 
   <header id="header" class="header d-flex align-items-center fixed-top">
-    <div class="container-fluid container-xl position-relative d-flex justify-content-around align-items-center">
+    <div class="container-fluid container-xl position-relative d-flex justify-content-between align-items-center">
 
       <a href="index.html" class="logo d-flex align-items-center">
         <img src="assets/img/logo.png" alt="">


### PR DESCRIPTION
## Summary
- enable header scroll handler to switch background to white
- center search bar in header

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68916a890d388328971a6f66811a65d3