### PR TITLE
fix: update search input focus color

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -221,6 +221,11 @@ h6 {
   border-radius: 20px;
 }
 
+.header .search-container input:focus {
+  border-color: #388da8;
+  outline: none;
+}
+
 .header .search-container .suggestions {
   position: absolute;
   top: calc(100% + 5px);


### PR DESCRIPTION
## Summary
- change search field border color to #388da8 on focus

## Testing
- `npm test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68917c2dbce88328a4d9d6fca7347ec8