### PR TITLE
Add expandable search history and responsive search layout

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -205,18 +205,19 @@ h6 {
   background: color-mix(in srgb, var(--accent-color), transparent 15%);
 }
 
+.header .container-fluid {
+  flex-wrap: wrap;
+}
+
 .header .search-container {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  position: relative;
   max-width: 400px;
   width: 100%;
 }
 
 .header .search-container input {
   width: 100%;
-  padding: 6px 12px;
+  padding: 6px 32px 6px 12px;
   border: 1px solid #ccc;
   border-radius: 20px;
 }
@@ -226,7 +227,16 @@ h6 {
   outline: none;
 }
 
-.header .search-container .suggestions {
+.header .search-container .search-icon {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%);
+  cursor: pointer;
+  color: #666;
+}
+
+.header .search-container .history-results {
   position: absolute;
   top: calc(100% + 5px);
   left: 0;
@@ -235,17 +245,51 @@ h6 {
   border: 1px solid #ccc;
   border-radius: 4px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-  display: none;
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
   z-index: 1000;
 }
 
-.header .search-container .suggestion-item {
-  padding: 8px 12px;
-  cursor: pointer;
+.header .search-container .history-results.open {
+  max-height: 300px;
+  opacity: 1;
 }
 
-.header .search-container .suggestion-item:hover {
-  background: #f0f0f0;
+.header .search-container .history-box {
+  padding: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.header .search-container .history-box .history-item {
+  padding: 5px 10px;
+  border: 1px solid #ccc;
+  border-radius: 15px;
+  background: #f8f9fa;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.header .search-container .history-box .history-item:hover {
+  background: #e9ecef;
+}
+
+.header .search-container .results-box {
+  padding: 10px;
+  border-top: 1px solid #eee;
+}
+
+@media (max-width: 768px) {
+  .header .search-container {
+    order: 3;
+    position: static;
+    transform: none;
+    width: 100%;
+    margin-top: 10px;
+  }
 }
 
 @media (max-width: 1200px) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -180,13 +180,12 @@
 })();
 
 const searchInput = document.getElementById('searchInput');
-const suggestionsBox = document.getElementById('suggestionsBox');
+const searchIcon = document.getElementById('searchIcon');
+const historyResults = document.getElementById('historyResults');
+const historyBox = document.getElementById('historyBox');
+const resultsBox = document.getElementById('resultsBox');
 
-if (searchInput && suggestionsBox) {
-  const suggestions = [
-    "apple", "banana", "cherry", "date", "grape", "mango", "melon", "orange"
-  ];
-
+if (searchInput && searchIcon && historyResults) {
   function getHistory() {
     return JSON.parse(localStorage.getItem('searchHistory') || '[]');
   }
@@ -195,54 +194,57 @@ if (searchInput && suggestionsBox) {
     if (!term) return;
     let history = getHistory().filter(item => item !== term);
     history.unshift(term);
-    history = history.slice(0, 5);
+    history = history.slice(0, 10);
     localStorage.setItem('searchHistory', JSON.stringify(history));
   }
 
-  function showSuggestions(items) {
-    if (items.length === 0) {
-      suggestionsBox.style.display = 'none';
-      return;
-    }
-    suggestionsBox.innerHTML = items.map(item => `<div class="suggestion-item">${item}</div>`).join('');
-    suggestionsBox.style.display = 'block';
+  function renderHistory() {
+    const history = getHistory();
+    historyBox.innerHTML = history.map(item => `<button class="history-item">${item}</button>`).join('');
   }
 
+  function performSearch(term) {
+    if (!term) return;
+    addHistory(term);
+    renderHistory();
+    resultsBox.innerHTML = `<div class="result-item">Bạn vừa tìm: <strong>${term}</strong></div>`;
+    openDropdown();
+  }
+
+  function openDropdown() {
+    historyResults.classList.add('open');
+  }
+
+  function closeDropdown() {
+    historyResults.classList.remove('open');
+  }
+
+  searchIcon.addEventListener('click', () => {
+    renderHistory();
+    historyResults.classList.toggle('open');
+  });
+
   searchInput.addEventListener('focus', () => {
-    if (searchInput.value.trim() === '') {
-      showSuggestions(getHistory());
-    }
-  });
-
-  searchInput.addEventListener('input', () => {
-    const keyword = searchInput.value.trim().toLowerCase();
-    if (keyword === '') {
-      showSuggestions(getHistory());
-      return;
-    }
-    const filtered = suggestions.filter(item => item.includes(keyword));
-    showSuggestions(filtered);
-  });
-
-  suggestionsBox.addEventListener('click', (e) => {
-    if (e.target.classList.contains('suggestion-item')) {
-      const value = e.target.textContent;
-      searchInput.value = value;
-      addHistory(value);
-      suggestionsBox.style.display = 'none';
-    }
+    renderHistory();
+    openDropdown();
   });
 
   searchInput.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') {
-      addHistory(searchInput.value.trim());
-      suggestionsBox.style.display = 'none';
+      performSearch(searchInput.value.trim());
+    }
+  });
+
+  historyBox.addEventListener('click', (e) => {
+    if (e.target.classList.contains('history-item')) {
+      searchInput.value = e.target.textContent;
+      performSearch(searchInput.value.trim());
     }
   });
 
   document.addEventListener('click', (e) => {
-    if (!searchInput.contains(e.target) && !suggestionsBox.contains(e.target)) {
-      suggestionsBox.style.display = 'none';
+    if (!historyResults.contains(e.target) && !searchInput.contains(e.target) && !searchIcon.contains(e.target)) {
+      closeDropdown();
     }
   });
 }

--- a/index.html
+++ b/index.html
@@ -50,7 +50,11 @@
 
       <div class="search-container">
         <input type="text" id="searchInput" placeholder="Search...">
-        <div id="suggestionsBox" class="suggestions"></div>
+        <i class="bi bi-search search-icon" id="searchIcon"></i>
+        <div id="historyResults" class="history-results">
+          <div id="historyBox" class="history-box"></div>
+          <div id="resultsBox" class="results-box"></div>
+        </div>
       </div>
 
       <a class="btn-getstarted" href="index.html#about">Get Started</a>

--- a/service-details.html
+++ b/service-details.html
@@ -48,7 +48,11 @@
 
       <div class="search-container mx-4">
         <input type="text" id="searchInput" placeholder="Search...">
-        <div id="suggestionsBox" class="suggestions"></div>
+        <i class="bi bi-search search-icon" id="searchIcon"></i>
+        <div id="historyResults" class="history-results">
+          <div id="historyBox" class="history-box"></div>
+          <div id="resultsBox" class="results-box"></div>
+        </div>
       </div>
 
       <nav id="navmenu" class="navmenu ms-auto">

--- a/starter-page.html
+++ b/starter-page.html
@@ -48,7 +48,11 @@
 
       <div class="search-container mx-4">
         <input type="text" id="searchInput" placeholder="Search...">
-        <div id="suggestionsBox" class="suggestions"></div>
+        <i class="bi bi-search search-icon" id="searchIcon"></i>
+        <div id="historyResults" class="history-results">
+          <div id="historyBox" class="history-box"></div>
+          <div id="resultsBox" class="results-box"></div>
+        </div>
       </div>
 
       <nav id="navmenu" class="navmenu ms-auto">


### PR DESCRIPTION
## Summary
- enhance search header with icon, recent term dropdown, and inline results
- style history dropdown with animation and mobile placement below header
- implement JS for storing last 10 searches and clickable history items

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689184015b3883289dd19d0677d4649f