### PR TITLE
Replace header search with navigation menu

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -209,13 +209,13 @@ h6 {
   flex-wrap: wrap;
 }
 
-.header .search-container {
+.search-container {
   position: relative;
   max-width: 400px;
   width: 100%;
 }
 
-.header .search-container input {
+.search-container input {
   width: 100%;
   padding: 6px 12px 6px 36px;
   border: none;
@@ -223,13 +223,13 @@ h6 {
   background: #f6f7f8;
 }
 
-.header .search-container input:focus {
+.search-container input:focus {
   outline: none;
   background: #fff;
   box-shadow: 0 0 0 1px #ccc;
 }
 
-.header .search-container .search-icon {
+.search-container .search-icon {
   position: absolute;
   top: 50%;
   left: 12px;
@@ -238,7 +238,7 @@ h6 {
   color: #666;
 }
 
-.header .search-container .history-results {
+.search-container .history-results {
   position: absolute;
   top: calc(100% + 5px);
   left: 0;
@@ -254,19 +254,19 @@ h6 {
   z-index: 1000;
 }
 
-.header .search-container .history-results.open {
+.search-container .history-results.open {
   max-height: 300px;
   opacity: 1;
 }
 
-.header .search-container .history-box {
+.search-container .history-box {
   padding: 10px;
   display: flex;
   flex-wrap: wrap;
   gap: 5px;
 }
 
-.header .search-container .history-box .history-item {
+.search-container .history-box .history-item {
   padding: 5px 10px;
   border: 1px solid #ccc;
   border-radius: 15px;
@@ -275,20 +275,17 @@ h6 {
   font-size: 14px;
 }
 
-.header .search-container .history-box .history-item:hover {
+.search-container .history-box .history-item:hover {
   background: #e9ecef;
 }
 
-.header .search-container .results-box {
+.search-container .results-box {
   padding: 10px;
   border-top: 1px solid #eee;
 }
 
 @media (max-width: 768px) {
-  .header .search-container {
-    order: 3;
-    position: static;
-    transform: none;
+  .search-container {
     width: 100%;
     margin-top: 10px;
   }
@@ -954,7 +951,7 @@ section,
   width: 100%;
   min-height: 70vh;
   position: relative;
-  padding: 180px 0 40px 0;
+  padding: 120px 0 40px 0;
   display: flex;
   align-items: center;
   overflow: hidden;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -259,23 +259,25 @@ const text = "単語を入力してください...";
 let index = 0;
 let typingTimeout; // phải khai báo biến này
 
-function typePlaceholder() {
-  if (index <= text.length) {
-    input.placeholder = text.substring(0, index);
-    index++;
-    typingTimeout = setTimeout(typePlaceholder, 80); // gán vào biến
-  } else {
-    typingTimeout = setTimeout(() => {
-      index = 0;
-      typePlaceholder();
-    }, 1500);
+if (input) {
+  function typePlaceholder() {
+    if (index <= text.length) {
+      input.placeholder = text.substring(0, index);
+      index++;
+      typingTimeout = setTimeout(typePlaceholder, 80); // gán vào biến
+    } else {
+      typingTimeout = setTimeout(() => {
+        index = 0;
+        typePlaceholder();
+      }, 1500);
+    }
   }
+
+  // Dừng khi focus vào input
+  input.addEventListener("focus", () => {
+    clearTimeout(typingTimeout);
+    input.placeholder = text;
+  });
+
+  typePlaceholder();
 }
-
-// Dừng khi focus vào input
-input.addEventListener("focus", () => {
-  clearTimeout(typingTimeout); 
-  input.placeholder=text;
-});
-
-typePlaceholder(); 

--- a/index.html
+++ b/index.html
@@ -34,21 +34,21 @@
 <body class="index-page">
 
   <header id="header" class="header d-flex align-items-center fixed-top">
-    <div class="container-fluid container-xl position-relative d-flex justify-content-between align-items-center">
+    <div class="container-fluid container-xl position-relative d-flex align-items-center">
 
       <a href="index.html" class="logo d-flex align-items-center">
         <img src="assets/img/logo.png" alt="">
         <h1 class="sitename">QuickStart</h1>
       </a>
 
-      <div class="search-container">
-        <input type="text" id="searchInput" placeholder="Search..." autocomplete="off">
-        <i class="bi bi-search search-icon" id="searchIcon"></i>
-        <div id="historyResults" class="history-results">
-          <div id="historyBox" class="history-box"></div>
-          <div id="resultsBox" class="results-box"></div>
-        </div>
-      </div>
+      <nav id="navmenu" class="navmenu ms-auto">
+        <ul>
+          <li><a href="#vocab">Vocab</a></li>
+          <li><a href="#flashcard">Flashcard</a></li>
+          <li><a href="#quiz">Quiz</a></li>
+        </ul>
+        <i class="mobile-nav-toggle d-xl-none bi bi-list"></i>
+      </nav>
 
       <a class="btn-getstarted" href="index.html#about">Get Started</a>
 

--- a/service-details.html
+++ b/service-details.html
@@ -46,40 +46,11 @@
         <h1 class="sitename">QuickStart</h1>
       </a>
 
-      <div class="search-container mx-4">
-        <input type="text" id="searchInput" placeholder="Search...">
-        <i class="bi bi-search search-icon" id="searchIcon"></i>
-        <div id="historyResults" class="history-results">
-          <div id="historyBox" class="history-box"></div>
-          <div id="resultsBox" class="results-box"></div>
-        </div>
-      </div>
-
       <nav id="navmenu" class="navmenu ms-auto">
         <ul>
-          <li><a href="index.html#hero">Home</a></li>
-          <li><a href="index.html#about">About</a></li>
-          <li><a href="index.html#features">Features</a></li>
-          <li><a href="index.html#services">Services</a></li>
-          <li><a href="index.html#pricing">Pricing</a></li>
-          <li class="dropdown"><a href="#"><span>Dropdown</span> <i class="bi bi-chevron-down toggle-dropdown"></i></a>
-            <ul>
-              <li><a href="#">Dropdown 1</a></li>
-              <li class="dropdown"><a href="#"><span>Deep Dropdown</span> <i class="bi bi-chevron-down toggle-dropdown"></i></a>
-                <ul>
-                  <li><a href="#">Deep Dropdown 1</a></li>
-                  <li><a href="#">Deep Dropdown 2</a></li>
-                  <li><a href="#">Deep Dropdown 3</a></li>
-                  <li><a href="#">Deep Dropdown 4</a></li>
-                  <li><a href="#">Deep Dropdown 5</a></li>
-                </ul>
-              </li>
-              <li><a href="#">Dropdown 2</a></li>
-              <li><a href="#">Dropdown 3</a></li>
-              <li><a href="#">Dropdown 4</a></li>
-            </ul>
-          </li>
-          <li><a href="index.html#contact">Contact</a></li>
+          <li><a href="#vocab">Vocab</a></li>
+          <li><a href="#flashcard">Flashcard</a></li>
+          <li><a href="#quiz">Quiz</a></li>
         </ul>
         <i class="mobile-nav-toggle d-xl-none bi bi-list"></i>
       </nav>

--- a/starter-page.html
+++ b/starter-page.html
@@ -46,40 +46,11 @@
         <h1 class="sitename">QuickStart</h1>
       </a>
 
-      <div class="search-container mx-4">
-        <input type="text" id="searchInput" placeholder="Search...">
-        <i class="bi bi-search search-icon" id="searchIcon"></i>
-        <div id="historyResults" class="history-results">
-          <div id="historyBox" class="history-box"></div>
-          <div id="resultsBox" class="results-box"></div>
-        </div>
-      </div>
-
       <nav id="navmenu" class="navmenu ms-auto">
         <ul>
-          <li><a href="index.html#hero">Home</a></li>
-          <li><a href="index.html#about">About</a></li>
-          <li><a href="index.html#features">Features</a></li>
-          <li><a href="index.html#services">Services</a></li>
-          <li><a href="index.html#pricing">Pricing</a></li>
-          <li class="dropdown"><a href="#"><span>Dropdown</span> <i class="bi bi-chevron-down toggle-dropdown"></i></a>
-            <ul>
-              <li><a href="#">Dropdown 1</a></li>
-              <li class="dropdown"><a href="#"><span>Deep Dropdown</span> <i class="bi bi-chevron-down toggle-dropdown"></i></a>
-                <ul>
-                  <li><a href="#">Deep Dropdown 1</a></li>
-                  <li><a href="#">Deep Dropdown 2</a></li>
-                  <li><a href="#">Deep Dropdown 3</a></li>
-                  <li><a href="#">Deep Dropdown 4</a></li>
-                  <li><a href="#">Deep Dropdown 5</a></li>
-                </ul>
-              </li>
-              <li><a href="#">Dropdown 2</a></li>
-              <li><a href="#">Dropdown 3</a></li>
-              <li><a href="#">Dropdown 4</a></li>
-            </ul>
-          </li>
-          <li><a href="index.html#contact">Contact</a></li>
+          <li><a href="#vocab">Vocab</a></li>
+          <li><a href="#flashcard">Flashcard</a></li>
+          <li><a href="#quiz">Quiz</a></li>
         </ul>
         <i class="mobile-nav-toggle d-xl-none bi bi-list"></i>
       </nav>


### PR DESCRIPTION
## Summary
- Remove header search box and add Vocab, Flashcard, and Quiz menu links.
- Style hero search area with global CSS and tighten hero section spacing.
- Guard search input placeholder animation to run only when input exists.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68920e2f1b548328b2e2fc07e6615865