### PR TITLE
style: highlight search bar

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -211,31 +211,34 @@ h6 {
 
 .search-container {
   position: relative;
-  max-width: 400px;
+  max-width: 600px;
   width: 100%;
 }
 
 .search-container input {
   width: 100%;
-  padding: 6px 12px 6px 36px;
-  border: none;
+  padding: 10px 20px 10px 50px;
+  font-size: 1.1rem;
+  border: 2px solid #0d6efd;
   border-radius: 50px;
-  background: #f6f7f8;
+  background: #fff;
+  box-shadow: 0 0 10px rgba(13, 110, 253, 0.15);
 }
 
 .search-container input:focus {
   outline: none;
   background: #fff;
-  box-shadow: 0 0 0 1px #ccc;
+  box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.25);
 }
 
 .search-container .search-icon {
   position: absolute;
   top: 50%;
-  left: 12px;
+  left: 20px;
   transform: translateY(-50%);
   cursor: pointer;
-  color: #666;
+  color: #0d6efd;
+  font-size: 1.2rem;
 }
 
 .search-container .history-results {


### PR DESCRIPTION
## Summary
- increase search bar width and padding for better visibility
- add accent border, shadow, and larger icon to highlight the search field

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892120189e883289b6fd2af2429acc7